### PR TITLE
change latitude and longitude from float to double

### DIFF
--- a/src/OsmSharp/Db/Impl/IHistoryDbImpl.cs
+++ b/src/OsmSharp/Db/Impl/IHistoryDbImpl.cs
@@ -69,7 +69,7 @@ namespace OsmSharp.Db.Impl
         /// - All non-archived relations with at least one member that is a node within the bounding box or a way with at least one node in the bounding box.
         /// - Sorted by type (node, way, relation) and then id ascending.
         /// </returns>
-        IEnumerable<OsmGeo> Get(float minLatitude, float minLongitude, float maxLatitude, float maxLongitude);
+        IEnumerable<OsmGeo> Get(double minLatitude, double minLongitude, double maxLatitude, double maxLongitude);
 
         /// <summary>
         /// Archives all the objects with the given keys.

--- a/src/OsmSharp/Db/Impl/MemoryHistoryDb.cs
+++ b/src/OsmSharp/Db/Impl/MemoryHistoryDb.cs
@@ -192,7 +192,7 @@ namespace OsmSharp.Db.Impl
         /// <summary>
         /// Gets all visbible objects within the given bounding box.
         /// </summary>
-        public IEnumerable<OsmGeo> Get(float minLatitude, float minLongitude, float maxLatitude, float maxLongitude)
+        public IEnumerable<OsmGeo> Get(double minLatitude, double minLongitude, double maxLatitude, double maxLongitude)
         {
             var nodesInBox = new HashSet<long>();
             var nodesToInclude = new HashSet<long>();

--- a/src/OsmSharp/IO/PBF/Encoder.cs
+++ b/src/OsmSharp/IO/PBF/Encoder.cs
@@ -659,7 +659,7 @@ namespace OsmSharp.IO.PBF
         /// Encodes a lat/lon value into an offset.
         /// </summary>
         /// <returns></returns>
-        public static long EncodeLatLon(float value, long offset, long granularity)
+        public static long EncodeLatLon(double value, long offset, long granularity)
         {
             return ((long)(value / .000000001) - offset) / granularity;
         }

--- a/src/OsmSharp/Node.cs
+++ b/src/OsmSharp/Node.cs
@@ -40,12 +40,12 @@ namespace OsmSharp
         /// <summary>
         /// The latitude.
         /// </summary>
-        public float? Latitude { get; set; }
+        public double? Latitude { get; set; }
 
         /// <summary>
         /// The longitude.
         /// </summary>
-        public float? Longitude { get; set; }
+        public double? Longitude { get; set; }
 
         /// <summary>
         /// Returns a description of this object.

--- a/src/OsmSharp/Utilities.cs
+++ b/src/OsmSharp/Utilities.cs
@@ -30,8 +30,8 @@ namespace OsmSharp
         /// <summary>
         /// Returns true if the given coordinate is inside the box.
         /// </summary>
-        public static bool IsInside(float boxLat1, float boxLon1, float boxLat2, float boxLon2, 
-            float lat, float lon)
+        public static bool IsInside(double boxLat1, double boxLon1, double boxLat2, double boxLon2,
+            double lat, double lon)
         {
             if (boxLat1 > boxLat2)
             {


### PR DESCRIPTION
Recently I'm working on indoor location and navigation.

In indoor scenario, the location precision must be more accurate then outdoor, because usually indoor room size is smaller, so the Tolerance also get smaller

in this article shows that when less digit will generate more deviation : [http://stackoverflow.com/a/12226557](http://stackoverflow.com/a/12226557)

even 5 digit still have 1.1 meter deviation

I've  test the current library usually get coordinate like below 
![image](https://cloud.githubusercontent.com/assets/891383/20000269/a9c44812-a2b1-11e6-88cd-80ff13e3824f.png)


After I update to double get more precise location
![image](https://cloud.githubusercontent.com/assets/891383/20000335/f219346a-a2b1-11e6-9498-16c3a5c9bcd6.png)
