### PR TITLE
Enhance precision of longitude and latitude data by changing their ty…

### DIFF
--- a/SharedAssemblyVersion.cs
+++ b/SharedAssemblyVersion.cs
@@ -18,5 +18,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyInformationalVersion("5.0.7-rc1")]
+[assembly: AssemblyInformationalVersion("5.0.7-rc1-private")]
 [assembly: AssemblyVersion("5.0.7")]

--- a/samples/Sample.GeoFilter/Program.cs
+++ b/samples/Sample.GeoFilter/Program.cs
@@ -44,7 +44,7 @@ namespace Sample.GeoFilter
                 var filtered = source.FilterSpatial(polygon, true);
 
                 // OPTION2: filter by bounding box.
-                // var filtered = source.FilterBox(6.238002777099609f, 49.72076145492323f, 6.272850036621093f, 49.69928180928878f);
+                // var filtered = source.FilterBox(6.238002777099609, 49.72076145492323, 6.272850036621093, 49.69928180928878);
 
                 // write to output xml
                 var target = new XmlOsmStreamTarget(fileStreamTarget);

--- a/samples/Sample.GeoFilter/README.md
+++ b/samples/Sample.GeoFilter/README.md
@@ -13,8 +13,8 @@ using (var fileStream = File.OpenRead("path/to/file.osm.pbf"))
   var source = new PBFOsmStreamSource(fileStream); 
   
   // filter by keeping everything inside the given polygon.
-  var filtered = source.FilterBox(6.238002777099609f, 49.72076145492323f, 
-    6.272850036621093f, 49.69928180928878f);
+  var filtered = source.FilterBox(6.238002777099609, 49.72076145492323, 
+    6.272850036621093, 49.69928180928878);
   ...
 }
 ```

--- a/src/OsmSharp/Changesets/Changeset.cs
+++ b/src/OsmSharp/Changesets/Changeset.cs
@@ -68,21 +68,21 @@ namespace OsmSharp.Changesets
         /// <summary>
         /// Gets or sets the minimum latitude.
         /// </summary>
-        public float? MinLatitude { get; set; }
+        public double? MinLatitude { get; set; }
 
         /// <summary>
         /// Gets or sets the minimum longitude.
         /// </summary>
-        public float? MinLongitude { get; set; }
+        public double? MinLongitude { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum latitude.
         /// </summary>
-        public float? MaxLatitude { get; set; }
+        public double? MaxLatitude { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum longitude.
         /// </summary>
-        public float? MaxLongitude { get; set; }
+        public double? MaxLongitude { get; set; }
     }
 }

--- a/src/OsmSharp/Db/HistoryDb.cs
+++ b/src/OsmSharp/Db/HistoryDb.cs
@@ -353,7 +353,7 @@ namespace OsmSharp.Db
             {
                 Results = results.ToArray(),
                 Generator = "OsmSharp",
-                Version = 0.6f
+                Version = 0.6
             }, DiffResultStatus.BestEffortOK);
         }
 

--- a/src/OsmSharp/Db/HistoryDb.cs
+++ b/src/OsmSharp/Db/HistoryDb.cs
@@ -174,7 +174,7 @@ namespace OsmSharp.Db
         /// <summary>
         /// Gets all visible objects within the given bounding box.
         /// </summary>
-        public IEnumerable<OsmGeo> Get(float minLatitude, float minLongitude, float maxLatitude, float maxLongitude)
+        public IEnumerable<OsmGeo> Get(double minLatitude, double minLongitude, double maxLatitude, double maxLongitude)
         {
             return _db.Get(minLatitude, minLongitude, maxLatitude, maxLongitude);
         }

--- a/src/OsmSharp/Db/IHistoryDb.cs
+++ b/src/OsmSharp/Db/IHistoryDb.cs
@@ -76,7 +76,7 @@ namespace OsmSharp.Db
         /// <summary>
         /// Gets all latest versions of osm objects within the given bounding box.
         /// </summary>
-        IEnumerable<OsmGeo> Get(float minLatitude, float minLongitude, float maxLatitude, float maxLongitude);
+        IEnumerable<OsmGeo> Get(double minLatitude, double minLongitude, double maxLatitude, double maxLongitude);
 
         /// <summary>
         /// Opens a new changeset.

--- a/src/OsmSharp/Db/Impl/IHistoryDbImpl.cs
+++ b/src/OsmSharp/Db/Impl/IHistoryDbImpl.cs
@@ -69,7 +69,7 @@ namespace OsmSharp.Db.Impl
         /// - All non-archived relations with at least one member that is a node within the bounding box or a way with at least one node in the bounding box.
         /// - Sorted by type (node, way, relation) and then id ascending.
         /// </returns>
-        IEnumerable<OsmGeo> Get(float minLatitude, float minLongitude, float maxLatitude, float maxLongitude);
+        IEnumerable<OsmGeo> Get(double minLatitude, double minLongitude, double maxLatitude, double maxLongitude);
 
         /// <summary>
         /// Archives all the objects with the given keys.

--- a/src/OsmSharp/Db/Impl/MemoryHistoryDb.cs
+++ b/src/OsmSharp/Db/Impl/MemoryHistoryDb.cs
@@ -192,7 +192,7 @@ namespace OsmSharp.Db.Impl
         /// <summary>
         /// Gets all visbible objects within the given bounding box.
         /// </summary>
-        public IEnumerable<OsmGeo> Get(float minLatitude, float minLongitude, float maxLatitude, float maxLongitude)
+        public IEnumerable<OsmGeo> Get(double minLatitude, double minLongitude, double maxLatitude, double maxLongitude)
         {
             var nodesInBox = new HashSet<long>();
             var nodesToInclude = new HashSet<long>();

--- a/src/OsmSharp/IO/PBF/Encoder.cs
+++ b/src/OsmSharp/IO/PBF/Encoder.cs
@@ -679,7 +679,7 @@ namespace OsmSharp.IO.PBF
         /// Encodes a lat/lon value into an offset.
         /// </summary>
         /// <returns></returns>
-        public static long EncodeLatLon(float value, long offset, long granularity)
+        public static long EncodeLatLon(double value, long offset, long granularity)
         {
             return ((long)(value / .000000001) - offset) / granularity;
         }
@@ -688,9 +688,9 @@ namespace OsmSharp.IO.PBF
         /// Decodes a lat/lon value from an offset.
         /// </summary>
         /// <returns></returns>
-        public static float DecodeLatLon(long valueOffset, long offset, long granularity)
+        public static double DecodeLatLon(long valueOffset, long offset, long granularity)
         {
-            return (float)(.000000001 * (offset + (granularity * valueOffset)));
+            return (.000000001 * (offset + (granularity * valueOffset)));
         }
 
         /// <summary>

--- a/src/OsmSharp/IO/Xml/Changesets/Changeset.Xml.cs
+++ b/src/OsmSharp/IO/Xml/Changesets/Changeset.Xml.cs
@@ -47,10 +47,10 @@ namespace OsmSharp.Changesets
             this.CreatedAt = reader.GetAttributeDateTime("created_at");
             this.ClosedAt = reader.GetAttributeDateTime("closed_at");
             this.Open = reader.GetAttributeBool("open");
-            this.MinLongitude = reader.GetAttributeSingle("min_lon");
-            this.MinLatitude = reader.GetAttributeSingle("min_lat");
-            this.MaxLongitude = reader.GetAttributeSingle("max_lon");
-            this.MaxLatitude = reader.GetAttributeSingle("max_lat");
+            this.MinLongitude = reader.GetAttributeDouble("min_lon");
+            this.MinLatitude = reader.GetAttributeDouble("min_lat");
+            this.MaxLongitude = reader.GetAttributeDouble("max_lon");
+            this.MaxLatitude = reader.GetAttributeDouble("max_lat");
 
             TagsCollection tags = null;
             while (reader.Read() &&

--- a/src/OsmSharp/IO/Xml/Node.Xml.cs
+++ b/src/OsmSharp/IO/Xml/Node.Xml.cs
@@ -43,8 +43,8 @@ namespace OsmSharp
         {
             this.Id = reader.GetAttributeInt64("id");
             this.Version = reader.GetAttributeInt32("version");
-            this.Latitude = reader.GetAttributeSingle("lat");
-            this.Longitude = reader.GetAttributeSingle("lon");
+            this.Latitude = reader.GetAttributeDouble("lat");
+            this.Longitude = reader.GetAttributeDouble("lon");
             this.ChangeSetId = reader.GetAttributeInt64("changeset");
             this.TimeStamp = reader.GetAttributeDateTime("timestamp");
             this.UserId = reader.GetAttributeInt32("uid");

--- a/src/OsmSharp/Node.cs
+++ b/src/OsmSharp/Node.cs
@@ -40,12 +40,12 @@ namespace OsmSharp
         /// <summary>
         /// The latitude.
         /// </summary>
-        public float? Latitude { get; set; }
+        public double? Latitude { get; set; }
 
         /// <summary>
         /// The longitude.
         /// </summary>
-        public float? Longitude { get; set; }
+        public double? Longitude { get; set; }
 
         /// <summary>
         /// Returns a description of this object.

--- a/src/OsmSharp/Utilities.cs
+++ b/src/OsmSharp/Utilities.cs
@@ -30,8 +30,8 @@ namespace OsmSharp
         /// <summary>
         /// Returns true if the given coordinate is inside the box.
         /// </summary>
-        public static bool IsInside(float boxLat1, float boxLon1, float boxLat2, float boxLon2, 
-            float lat, float lon)
+        public static bool IsInside(double boxLat1, double boxLon1, double boxLat2, double boxLon2,
+            double lat, double lon)
         {
             if (boxLat1 > boxLat2)
             {

--- a/test/OsmSharp.Test/Geo/DefaultFeatureInterpreterTests.cs
+++ b/test/OsmSharp.Test/Geo/DefaultFeatureInterpreterTests.cs
@@ -232,26 +232,26 @@ namespace OsmSharp.Test.Geo
                 new Node()
                 {
                     Id = 5,
-                    Latitude = 0.25f,
-                    Longitude = 0.25f
+                    Latitude = 0.25,
+                    Longitude = 0.25
                 },
                 new Node()
                 {
                     Id = 6,
-                    Latitude = 0.25f,
-                    Longitude = 0.40f
+                    Latitude = 0.25,
+                    Longitude = 0.40
                 },
                 new Node()
                 {
                     Id = 7,
-                    Latitude = 0.40f,
-                    Longitude = 0.40f
+                    Latitude = 0.40,
+                    Longitude = 0.40
                 },
                 new Node()
                 {
                     Id = 8,
-                    Latitude = 0.40f,
-                    Longitude = 0.25f
+                    Latitude = 0.40,
+                    Longitude = 0.25
                 },
                 new Way()
                 {
@@ -340,50 +340,50 @@ namespace OsmSharp.Test.Geo
                 new Node()
                 {
                     Id = 5,
-                    Latitude = 0.25f,
-                    Longitude = 0.25f
+                    Latitude = 0.25,
+                    Longitude = 0.25
                 },
                 new Node()
                 {
                     Id = 6,
-                    Latitude = 0.25f,
-                    Longitude = 0.40f
+                    Latitude = 0.25,
+                    Longitude = 0.40
                 },
                 new Node()
                 {
                     Id = 7,
-                    Latitude = 0.40f,
-                    Longitude = 0.40f
+                    Latitude = 0.40,
+                    Longitude = 0.40
                 },
                 new Node()
                 {
                     Id = 8,
-                    Latitude = 0.40f,
-                    Longitude = 0.25f
+                    Latitude = 0.40,
+                    Longitude = 0.25
                 },
                 new Node()
                 {
                     Id = 9,
-                    Latitude = 0.60f,
-                    Longitude = 0.25f
+                    Latitude = 0.60,
+                    Longitude = 0.25
                 },
                 new Node()
                 {
                     Id = 10,
-                    Latitude = 0.60f,
-                    Longitude = 0.40f
+                    Latitude = 0.60,
+                    Longitude = 0.40
                 },
                 new Node()
                 {
                     Id = 11,
-                    Latitude = 0.75f,
-                    Longitude = 0.40f
+                    Latitude = 0.75,
+                    Longitude = 0.40
                 },
                 new Node()
                 {
                     Id = 12,
-                    Latitude = 0.75f,
-                    Longitude = 0.25f
+                    Latitude = 0.75,
+                    Longitude = 0.25
                 },
                 new Way()
                 {
@@ -486,26 +486,26 @@ namespace OsmSharp.Test.Geo
                 new Node()
                 {
                     Id = 5,
-                    Latitude = 0.25f,
-                    Longitude = 0.25f
+                    Latitude = 0.25,
+                    Longitude = 0.25
                 },
                 new Node()
                 {
                     Id = 6,
-                    Latitude = 0.25f,
-                    Longitude = 0.40f
+                    Latitude = 0.25,
+                    Longitude = 0.40
                 },
                 new Node()
                 {
                     Id = 7,
-                    Latitude = 0.40f,
-                    Longitude = 0.40f
+                    Latitude = 0.40,
+                    Longitude = 0.40
                 },
                 new Node()
                 {
                     Id = 8,
-                    Latitude = 0.40f,
-                    Longitude = 0.25f
+                    Latitude = 0.40,
+                    Longitude = 0.25
                 },
                 new Way()
                 {

--- a/test/OsmSharp.Test/IO/PBF/EncoderTests.cs
+++ b/test/OsmSharp.Test/IO/PBF/EncoderTests.cs
@@ -57,6 +57,9 @@ namespace OsmSharp.Test.IO.PBF
             Assert.AreEqual(0, Encoder.DecodeLatLon(0, 0, 100));
             Assert.AreEqual(180, Encoder.DecodeLatLon(1800000000, 0, 100));
             Assert.AreEqual(-180, Encoder.DecodeLatLon(-1800000000, 0, 100));
+
+            Assert.AreEqual(19.0471020, Encoder.DecodeLatLon(190471020, 0, 100), .000000001);
+            Assert.AreEqual(47.5135549, Encoder.DecodeLatLon(475135549, 0, 100), .000000001);
         }
 
         /// <summary>
@@ -104,8 +107,8 @@ namespace OsmSharp.Test.IO.PBF
                     user_sid = 3,
                     version = 2
                 },
-                lat = Encoder.EncodeLatLon(10.9f, block.lat_offset, block.granularity),
-                lon = Encoder.EncodeLatLon(11.0f, block.lat_offset, block.granularity)
+                lat = Encoder.EncodeLatLon(10.9, block.lat_offset, block.granularity),
+                lon = Encoder.EncodeLatLon(11.0, block.lat_offset, block.granularity)
             };
             pbfNode.keys.Add(1);
             pbfNode.vals.Add(2);
@@ -114,8 +117,8 @@ namespace OsmSharp.Test.IO.PBF
             Assert.IsNotNull(node);
             Assert.AreEqual(1, node.Id);
             Assert.AreEqual(10, node.ChangeSetId);
-            Assert.AreEqual(10.9f, node.Latitude);
-            Assert.AreEqual(11.0f, node.Longitude);
+            Assert.AreEqual(10.9, node.Latitude);
+            Assert.AreEqual(11.0, node.Longitude);
             Assert.AreEqual(PBFExtensions.FromUnixTime(10000), node.TimeStamp);
             Assert.AreEqual(OsmSharp.OsmGeoType.Node, node.Type);
             Assert.AreEqual(100, node.UserId);
@@ -408,8 +411,8 @@ namespace OsmSharp.Test.IO.PBF
                     user_sid = 2,
                     version = 2
                 },
-                lat = Encoder.EncodeLatLon(10.9f, block.lat_offset, block.granularity),
-                lon = Encoder.EncodeLatLon(11.0f, block.lat_offset, block.granularity)
+                lat = Encoder.EncodeLatLon(10.9, block.lat_offset, block.granularity),
+                lon = Encoder.EncodeLatLon(11.0, block.lat_offset, block.granularity)
             };
             node.keys.Add(0);
             node.vals.Add(1);
@@ -480,16 +483,16 @@ namespace OsmSharp.Test.IO.PBF
             primitiveGroup.dense.keys_vals.Add(0); // highway=track.
             primitiveGroup.dense.keys_vals.Add(0); // empty.
 
-            primitiveGroup.dense.lat.Add(Encoder.EncodeLatLon(10.0f, block.lat_offset, block.granularity));
-            primitiveGroup.dense.lat.Add(Encoder.EncodeLatLon(11.0f, block.lat_offset, block.granularity)
+            primitiveGroup.dense.lat.Add(Encoder.EncodeLatLon(10.0, block.lat_offset, block.granularity));
+            primitiveGroup.dense.lat.Add(Encoder.EncodeLatLon(11.0, block.lat_offset, block.granularity)
                 - primitiveGroup.dense.lat[primitiveGroup.dense.lat.Count - 1]);
-            primitiveGroup.dense.lat.Add(Encoder.EncodeLatLon(12.0f, block.lat_offset, block.granularity)
+            primitiveGroup.dense.lat.Add(Encoder.EncodeLatLon(12.0, block.lat_offset, block.granularity)
                 - primitiveGroup.dense.lat[primitiveGroup.dense.lat.Count - 1]);
 
-            primitiveGroup.dense.lon.Add(Encoder.EncodeLatLon(100.0f, block.lon_offset, block.granularity));
-            primitiveGroup.dense.lon.Add(Encoder.EncodeLatLon(110.0f, block.lon_offset, block.granularity)
+            primitiveGroup.dense.lon.Add(Encoder.EncodeLatLon(100.0, block.lon_offset, block.granularity));
+            primitiveGroup.dense.lon.Add(Encoder.EncodeLatLon(110.0, block.lon_offset, block.granularity)
                 - primitiveGroup.dense.lon[primitiveGroup.dense.lon.Count - 1]);
-            primitiveGroup.dense.lon.Add(Encoder.EncodeLatLon(120.0f, block.lon_offset, block.granularity)
+            primitiveGroup.dense.lon.Add(Encoder.EncodeLatLon(120.0, block.lon_offset, block.granularity)
                 - primitiveGroup.dense.lon[primitiveGroup.dense.lon.Count - 1]);
 
             block.primitivegroup.Add(primitiveGroup);

--- a/test/OsmSharp.Test/IO/Xml/Changesets/ChangesetTests.cs
+++ b/test/OsmSharp.Test/IO/Xml/Changesets/ChangesetTests.cs
@@ -58,7 +58,7 @@ namespace OsmSharp.Test.IO.Xml.Changesets
             };
 
             var result = changeset.SerializeToXml();
-            Assert.AreEqual("<changeset id=\"10\" user=\"fred\" uid=\"123\" created_at=\"2008-11-08T19:07:39Z\" open=\"true\" min_lon=\"7.019182\" min_lat=\"49.27854\" max_lon=\"7.019749\" max_lat=\"49.27931\"><tag k=\"created_by\" v=\"JOSM 1.61\" /><tag k=\"comment\" v=\"Just adding some streetnames\" /></changeset>",
+            Assert.AreEqual("<changeset id=\"10\" user=\"fred\" uid=\"123\" created_at=\"2008-11-08T19:07:39Z\" open=\"true\" min_lon=\"7.0191821\" min_lat=\"49.2785426\" max_lon=\"7.0197485\" max_lat=\"49.2793101\"><tag k=\"created_by\" v=\"JOSM 1.61\" /><tag k=\"comment\" v=\"Just adding some streetnames\" /></changeset>",
                 result);
         }
 
@@ -76,7 +76,7 @@ namespace OsmSharp.Test.IO.Xml.Changesets
             Assert.AreEqual(10, changeset.Id);
 
             changeset = serializer.Deserialize(
-                new StringReader("<changeset id=\"10\" user=\"fred\" uid=\"123\" created_at=\"2008-11-08T19:07:39Z\" open=\"true\" min_lon=\"7.019182\" min_lat=\"49.27854\" max_lon=\"7.019749\" max_lat=\"49.27931\"><tag k=\"created_by\" v=\"JOSM 1.61\" /><tag k=\"comment\" v=\"Just adding some streetnames\" /></changeset>")) as Changeset;
+                new StringReader("<changeset id=\"10\" user=\"fred\" uid=\"123\" created_at=\"2008-11-08T19:07:39Z\" open=\"true\" min_lon=\"7.0191821\" min_lat=\"49.2785426\" max_lon=\"7.0197485\" max_lat=\"49.2793101\"><tag k=\"created_by\" v=\"JOSM 1.61\" /><tag k=\"comment\" v=\"Just adding some streetnames\" /></changeset>")) as Changeset;
             Assert.IsNotNull(changeset);
             Assert.AreEqual(10, changeset.Id);
             Assert.AreEqual(123, changeset.UserId);
@@ -87,7 +87,7 @@ namespace OsmSharp.Test.IO.Xml.Changesets
             Assert.AreEqual(7.0191821, changeset.MinLongitude, .000000001);
             Assert.AreEqual(49.2785426, changeset.MinLatitude, .000000001);
             Assert.AreEqual(7.0197485, changeset.MaxLongitude, .000000001);
-            Assert.AreEqual(49.27931011, changeset.MaxLatitude, .000000001);
+            Assert.AreEqual(49.2793101, changeset.MaxLatitude, .000000001);
 
             Assert.IsNotNull(changeset.Tags);
             Assert.AreEqual(2, changeset.Tags.Count);

--- a/test/OsmSharp.Test/IO/Xml/Changesets/ChangesetTests.cs
+++ b/test/OsmSharp.Test/IO/Xml/Changesets/ChangesetTests.cs
@@ -44,10 +44,10 @@ namespace OsmSharp.Test.IO.Xml.Changesets
             var changeset = new Changeset()
             {
                 Id = 10,
-                MinLatitude = 49.2785426f,
-                MinLongitude = 7.0191821f,
-                MaxLatitude = 49.2793101f,
-                MaxLongitude = 7.0197485f,
+                MinLatitude = 49.2785426,
+                MinLongitude = 7.0191821,
+                MaxLatitude = 49.2793101,
+                MaxLongitude = 7.0197485,
                 Open = true,
                 CreatedAt = new System.DateTime(2008, 11, 08, 19, 07, 39),
                 UserId = 123,
@@ -84,10 +84,10 @@ namespace OsmSharp.Test.IO.Xml.Changesets
             Assert.AreEqual(new System.DateTime(2008, 11, 08, 19, 07, 39), changeset.CreatedAt.Value.ToUniversalTime());
             Assert.IsNull(changeset.ClosedAt);
             Assert.AreEqual(true, changeset.Open);
-            Assert.AreEqual(7.0191821f, changeset.MinLongitude, 0.00001f);
-            Assert.AreEqual(49.2785426f, changeset.MinLatitude, 0.00001f);
-            Assert.AreEqual(7.0197485f, changeset.MaxLongitude, 0.00001f);
-            Assert.AreEqual(49.27931011f, changeset.MaxLatitude, 0.00001f);
+            Assert.AreEqual(7.0191821, changeset.MinLongitude, .000000001);
+            Assert.AreEqual(49.2785426, changeset.MinLatitude, .000000001);
+            Assert.AreEqual(7.0197485, changeset.MaxLongitude, .000000001);
+            Assert.AreEqual(49.27931011, changeset.MaxLatitude, .000000001);
 
             Assert.IsNotNull(changeset.Tags);
             Assert.AreEqual(2, changeset.Tags.Count);

--- a/test/OsmSharp.Test/IO/Xml/NodeTests.cs
+++ b/test/OsmSharp.Test/IO/Xml/NodeTests.cs
@@ -52,8 +52,8 @@ namespace OsmSharp.Test.IO.Xml
             {
                 Id = 1,
                 Version = 1,
-                Latitude = 54.10f,
-                Longitude = 12.2f,
+                Latitude = 54.10,
+                Longitude = 12.2,
                 UserName = "ben",
                 UserId = 1
             };
@@ -63,8 +63,8 @@ namespace OsmSharp.Test.IO.Xml
             {
                 Id = 1,
                 Version = 1,
-                Latitude = 54.10f,
-                Longitude = 12.2f,
+                Latitude = 54.10,
+                Longitude = 12.2,
                 UserName = "ben",
                 UserId = 1,
                 TimeStamp = new System.DateTime(2008, 09, 12, 21, 37, 45),
@@ -93,8 +93,8 @@ namespace OsmSharp.Test.IO.Xml
                 new StringReader("<node id=\"1\" lat=\"54.1\" lon=\"12.2\" user=\"ben\" uid=\"1\" version=\"1\" />")) as Node;
             Assert.IsNotNull(node);
             Assert.AreEqual(1, node.Id);
-            Assert.AreEqual(54.1f, node.Latitude);
-            Assert.AreEqual(12.2f, node.Longitude);
+            Assert.AreEqual(54.1, node.Latitude);
+            Assert.AreEqual(12.2, node.Longitude);
             Assert.AreEqual("ben", node.UserName);
             Assert.AreEqual(1, node.UserId);
             Assert.AreEqual(1, node.Version);
@@ -103,8 +103,8 @@ namespace OsmSharp.Test.IO.Xml
                 new StringReader("<node id=\"1\" lat=\"54.1\" lon=\"12.2\" user=\"ben\" uid=\"1\" version=\"1\" timestamp=\"2008-09-12T21:37:45Z\"><tag k=\"amenity\" v=\"something\" /><tag k=\"key\" v=\"some_value\" /></node>")) as Node;
             Assert.IsNotNull(node);
             Assert.AreEqual(1, node.Id);
-            Assert.AreEqual(54.1f, node.Latitude);
-            Assert.AreEqual(12.2f, node.Longitude);
+            Assert.AreEqual(54.1, node.Latitude);
+            Assert.AreEqual(12.2, node.Longitude);
             Assert.AreEqual("ben", node.UserName);
             Assert.AreEqual(1, node.UserId);
             Assert.AreEqual(1, node.Version);

--- a/test/OsmSharp.Test/Stream/PBFOsmStreamTargetTests.cs
+++ b/test/OsmSharp.Test/Stream/PBFOsmStreamTargetTests.cs
@@ -46,8 +46,8 @@ namespace OsmSharp.Test.Stream
             var sourceNode = new Node()
             {
                 Id = 1,
-                Latitude = 1.1f,
-                Longitude = 1.2f
+                Latitude = 1.1,
+                Longitude = 1.2
             };
             var sourceObjects = new OsmGeo[] {
                 sourceNode
@@ -74,16 +74,16 @@ namespace OsmSharp.Test.Stream
                 Assert.AreEqual(0, resultObjects[0].Version);
 
                 var resultNode = resultObjects[0] as Node;
-                Assert.AreEqual(sourceNode.Latitude.Value, resultNode.Latitude.Value, .0001f);
-                Assert.AreEqual(sourceNode.Longitude.Value, resultNode.Longitude.Value, .0001f);
+                Assert.AreEqual(sourceNode.Latitude.Value, resultNode.Latitude.Value, .000000001);
+                Assert.AreEqual(sourceNode.Longitude.Value, resultNode.Longitude.Value, .000000001);
             }
 
             // build source stream.
             sourceNode = new Node()
             {
                 Id = 1,
-                Latitude = 1.1f,
-                Longitude = 1.2f
+                Latitude = 1.1,
+                Longitude = 1.2
             };
             sourceNode.Tags = new TagsCollection();
             sourceNode.Tags.Add("highway", "residential");
@@ -114,16 +114,16 @@ namespace OsmSharp.Test.Stream
                 Assert.IsTrue(resultObjects[0].Tags.Contains(sourceObjects[0].Tags.First<Tag>()));
 
                 var resultNode = resultObjects[0] as Node;
-                Assert.AreEqual(sourceNode.Latitude.Value, resultNode.Latitude.Value, .0001f);
-                Assert.AreEqual(sourceNode.Longitude.Value, resultNode.Longitude.Value, .0001f);
+                Assert.AreEqual(sourceNode.Latitude.Value, resultNode.Latitude.Value, .000000001);
+                Assert.AreEqual(sourceNode.Longitude.Value, resultNode.Longitude.Value, .000000001);
             }
 
             // build source stream.
             sourceNode = new Node()
             {
                 Id = 1,
-                Latitude = 1.1f,
-                Longitude = 1.2f
+                Latitude = 1.1,
+                Longitude = 1.2
             };
             sourceNode.Tags = new TagsCollection();
             sourceNode.Tags.Add("highway", "residential");
@@ -160,8 +160,8 @@ namespace OsmSharp.Test.Stream
                 Assert.IsTrue(resultObjects[0].Tags.Contains(sourceObjects[0].Tags.First<Tag>()));
 
                 var resultNode = resultObjects[0] as Node;
-                Assert.AreEqual(sourceNode.Latitude.Value, resultNode.Latitude.Value, .0001f);
-                Assert.AreEqual(sourceNode.Longitude.Value, resultNode.Longitude.Value, .0001f);
+                Assert.AreEqual(sourceNode.Latitude.Value, resultNode.Latitude.Value, .000000001);
+                Assert.AreEqual(sourceNode.Longitude.Value, resultNode.Longitude.Value, .000000001);
             }
         }
 
@@ -486,8 +486,8 @@ namespace OsmSharp.Test.Stream
             var sourceNode = new Node()
             {
                 Id = 1,
-                Latitude = 1.1f,
-                Longitude = 1.2f
+                Latitude = 1.1,
+                Longitude = 1.2
             };
             sourceNode.Tags = new TagsCollection();
             sourceNode.Tags.Add("highway", "residential");
@@ -569,8 +569,8 @@ namespace OsmSharp.Test.Stream
                 Assert.IsTrue(resultObjects[0].Tags.Contains(sourceObjects[0].Tags.First<Tag>()));
 
                 var resultNode = resultObjects[0] as Node;
-                Assert.AreEqual(sourceNode.Latitude.Value, resultNode.Latitude.Value, .0001f);
-                Assert.AreEqual(sourceNode.Longitude.Value, resultNode.Longitude.Value, .0001f);
+                Assert.AreEqual(sourceNode.Latitude.Value, resultNode.Latitude.Value, .000000001);
+                Assert.AreEqual(sourceNode.Longitude.Value, resultNode.Longitude.Value, .000000001);
 
                 Assert.AreEqual(sourceObjects[1].Id, resultObjects[1].Id);
                 Assert.AreEqual(sourceObjects[1].ChangeSetId, resultObjects[1].ChangeSetId);

--- a/test/OsmSharp.Test/Stream/XmlOsmStreamSourceTests.cs
+++ b/test/OsmSharp.Test/Stream/XmlOsmStreamSourceTests.cs
@@ -54,8 +54,8 @@ namespace OsmSharp.Test.Stream
             Assert.IsInstanceOf<Node>(result[0]);
             var node = result[0] as Node;
             Assert.AreEqual(471625991, node.Id);
-            Assert.AreEqual(51.2704712f, node.Latitude);
-            Assert.AreEqual(4.8006659f, node.Longitude);
+            Assert.AreEqual(51.2704712, node.Latitude);
+            Assert.AreEqual(4.8006659, node.Longitude);
             Assert.AreEqual("marc12", node.UserName);
             Assert.AreEqual(540527, node.UserId);
             Assert.AreEqual(true, node.Visible);

--- a/test/OsmSharp.Test/Stream/XmlOsmStreamTargetTests.cs
+++ b/test/OsmSharp.Test/Stream/XmlOsmStreamTargetTests.cs
@@ -124,20 +124,20 @@ namespace OsmSharp.Test.Stream
                 new Node()
                 {
                     Id = 1,
-                    Latitude = 1.0f,
-                    Longitude = 1.1f
+                    Latitude = 1.0,
+                    Longitude = 1.1
                 },
                 new Node()
                 {
                     Id = 2,
-                    Latitude = 2.0f,
-                    Longitude = 2.1f
+                    Latitude = 2.0,
+                    Longitude = 2.1
                 },
                 new Node()
                 {
                     Id = 3,
-                    Latitude = 3.0f,
-                    Longitude = 3.1f
+                    Latitude = 3.0,
+                    Longitude = 3.1
                 },
                 new Way()
                 {


### PR DESCRIPTION
…pe from float to double.

Reason: http://wiki.openstreetmap.org/wiki/Node - "Do not use IEEE 32-bit floating point data type since it is limited to about 5 decimal places."