### PR TITLE
Fix V3102

### DIFF
--- a/src/OsmSharp/IO/Xml/Changesets/DiffResult.Xml.cs
+++ b/src/OsmSharp/IO/Xml/Changesets/DiffResult.Xml.cs
@@ -112,7 +112,7 @@ namespace OsmSharp.Changesets
             {
                 for (var i = 0; i < this.Results.Length; i++)
                 {
-                    var result = this.Results[0] as IXmlSerializable;
+                    var result = this.Results[i] as IXmlSerializable;
                     if (result is NodeResult)
                     {
                         writer.WriteStartElement("node");


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Suspicious access to element of 'this.Results' object by a constant index inside a loop. OsmSharp DiffResult.Xml.cs 115