### PR TITLE
Parsing Latitude and Longitude with double precision (Node.Xml.cs)

### DIFF
--- a/src/OsmSharp/IO/Xml/Node.Xml.cs
+++ b/src/OsmSharp/IO/Xml/Node.Xml.cs
@@ -43,8 +43,8 @@ namespace OsmSharp
         {
             this.Id = reader.GetAttributeInt64("id");
             this.Version = reader.GetAttributeInt32("version");
-            this.Latitude = reader.GetAttributeSingle("lat");
-            this.Longitude = reader.GetAttributeSingle("lon");
+            this.Latitude = reader.GetAttributeDouble("lat");
+            this.Longitude = reader.GetAttributeDouble("lon");
             this.ChangeSetId = reader.GetAttributeInt64("changeset");
             this.TimeStamp = reader.GetAttributeDateTime("timestamp");
             this.UserId = reader.GetAttributeInt32("uid");


### PR DESCRIPTION
Fixed the problem that despite the Longitude and Latitude being double data types in Node.cs, while parsing from Xml, they were being read in single precision. Changed it to read in double precision to avoid loss of information