### PR TITLE
[master]: Changing XmlExtentions.GetElements() to skip unexpected Xml…

### DIFF
--- a/src/OsmSharp/IO/Xml/XmlExtensions.cs
+++ b/src/OsmSharp/IO/Xml/XmlExtensions.cs
@@ -193,22 +193,29 @@ namespace OsmSharp.IO.Xml
         /// </summary>
         public static void GetElements(this XmlReader reader, Dictionary<string, Action> getElements)
         {
+            var parentName = reader.Name;
             reader.Read();
+
             while (reader.MoveToContent() != XmlNodeType.None)
             {
-                Action action;
-                if(!getElements.TryGetValue(reader.Name, out action))
+                if (getElements.TryGetValue(reader.Name, out Action action))
                 {
-                    if (reader.Name != "osm")
-                    {
-                        Logger.Log("XmlExtensions", TraceEventType.Verbose, "No action found for xml node with name {0}.", reader.Name);
-                    }
-                    break;
+                    action();
                 }
-                action();
+                else
+                {
+                    Logger.Log("XmlExtensions", TraceEventType.Verbose, "No action found for xml node with name {0}. Skipping it.", reader.Name);
+                    reader.Read();
+                }
 
                 if (reader.NodeType == XmlNodeType.EndElement)
                 {
+                    if (reader.Name == parentName)
+                    {
+                        reader.Read();
+                        break;
+                    }
+
                     reader.Read();
                 }
             }

--- a/test/OsmSharp.Test/IO/Xml/API/OsmTests.cs
+++ b/test/OsmSharp.Test/IO/Xml/API/OsmTests.cs
@@ -114,5 +114,48 @@ namespace OsmSharp.Test.IO.Xml.API
             Assert.IsNotNull(capabilities.WayNodes);
             Assert.AreEqual(2000, capabilities.WayNodes.Maximum);
         }
+
+        /// <summary>
+        /// Test deserialization of XML that contains unexpected elements (for example 'note' and 'meta' from an OverpassApi result).
+        /// </summary>
+        [Test]
+        public void TestDeserializeSkippingUnexpectedElements()
+        {
+            var xml =
+@"<?xml version=""1.0"" encoding=""UTF-8""?>
+<osm version=""0.6"" generator=""Overpass API 0.7.55.7 8b86ff77"">
+    <note>This is just a note</note>
+    <meta osm_base=""2019-07-27T00:04:02Z"" areas=""2019-07-26T23:48:03Z""/>
+    <node id=""1"" lat=""111"" lon=""-70.111"">
+        <tag k=""addr:housenumber"" v=""11""/>
+        <tag k=""addr:street"" v=""Main Street""/>
+    </node>
+</osm>";
+            var serializer = new XmlSerializer(typeof(Osm));
+            var osm = serializer.Deserialize(new StringReader(xml)) as Osm;
+            Assert.IsNotNull(osm);
+            Assert.AreEqual(.6, osm.Version);
+            Assert.AreEqual("Overpass API 0.7.55.7 8b86ff77", osm.Generator);
+
+            Assert.IsNull(osm.Ways);
+            Assert.IsNull(osm.Relations);
+            Assert.IsNull(osm.User);
+            Assert.IsNull(osm.GpxFiles);
+            Assert.IsNull(osm.Bounds);
+            Assert.IsNull(osm.Api);
+
+            Assert.IsNotNull(osm.Nodes);
+            Assert.AreEqual(1, osm.Nodes.Length);
+            var node = osm.Nodes[0];
+            Assert.AreEqual(1, node.Id);
+            Assert.AreEqual(111, node.Latitude);
+            Assert.AreEqual(-70.111, node.Longitude);
+            Assert.NotNull(node.Tags);
+            Assert.AreEqual(2, node.Tags.Count);
+            Assert.True(node.Tags.ContainsKey("addr:housenumber"));
+            Assert.AreEqual("11", node.Tags["addr:housenumber"]);
+            Assert.True(node.Tags.ContainsKey("addr:street"));
+            Assert.AreEqual("Main Street", node.Tags["addr:street"]);
+        }
     }
 }


### PR DESCRIPTION
Changing XmlExtentions.GetElements() to skip unexpected XmlElements instead of just stopping.

Adding test call for Osm.ReadXml() using a sample response from OverpassApi, which includes unexpected XmlElements.

My attempt at fixing https://github.com/OsmSharp/core/issues/76