### PR TITLE
[blackboxlogic-Issue-80]:

### DIFF
--- a/src/OsmSharp/IO/Xml/API/Bounds.Xml.cs
+++ b/src/OsmSharp/IO/Xml/API/Bounds.Xml.cs
@@ -44,6 +44,7 @@ namespace OsmSharp.API
             this.MinLongitude = reader.GetAttributeSingle("minlon");
             this.MaxLatitude = reader.GetAttributeSingle("maxlat");
             this.MaxLongitude = reader.GetAttributeSingle("maxlon");
+            reader.Read();
         }
 
         void IXmlSerializable.WriteXml(XmlWriter writer)

--- a/test/OsmSharp.Test/IO/Xml/API/OsmTests.cs
+++ b/test/OsmSharp.Test/IO/Xml/API/OsmTests.cs
@@ -23,6 +23,8 @@
 using NUnit.Framework;
 using OsmSharp.API;
 using OsmSharp.IO.Xml;
+using System;
+using System.Globalization;
 using System.IO;
 using System.Xml.Serialization;
 
@@ -44,7 +46,7 @@ namespace OsmSharp.Test.IO.Xml.API
             {
                 Api = new Capabilities()
                 {
-                    Version = new Version()
+                    Version = new OsmSharp.API.Version()
                     {
                         Maximum = 0.6,
                         Minimum = 0.6
@@ -157,6 +159,93 @@ namespace OsmSharp.Test.IO.Xml.API
             Assert.AreEqual("11", node.Tags["addr:housenumber"]);
             Assert.True(node.Tags.ContainsKey("addr:street"));
             Assert.AreEqual("Main Street", node.Tags["addr:street"]);
+        }
+
+        /// <summary>
+        /// Test deserialization of XML that contains bounds.
+        /// </summary>
+        [Test]
+        public void TestDeserializeWithBoundsElement()
+        {
+            var xml =
+                @"<?xml version=""1.0"" encoding=""UTF-8""?>
+                <osm version=""0.6"" generator=""CGImap 0.7.5 (5035 errol.openstreetmap.org)"" copyright=""OpenStreetMap and contributors"" attribution=""http://www.openstreetmap.org/copyright"" license=""http://opendatacommons.org/licenses/odbl/1-0/"">
+                 <bounds minlat=""38.9070200"" minlon=""-77.0371900"" maxlat=""38.9077300"" maxlon=""-77.0360000""/>
+                 <node id=""8549479"" visible=""true"" version=""6"" changeset=""17339"" timestamp=""2013-01-20T06:31:24Z"" user=""samanbb"" uid=""933"" lat=""38.8921989"" lon=""-77.0503034""/>
+                 <node id=""8549530"" visible=""false"" version=""2"" changeset=""17248"" timestamp=""2013-01-17T15:24:35Z"" user=""ideditor"" uid=""912"" lat=""38.9065506"" lon=""-77.0345080""/>
+                 <way id=""538868"" visible=""true"" version=""5"" changeset=""23710"" timestamp=""2013-05-28T17:45:26Z"" user=""Kate"" uid=""1163"">
+                  <nd ref=""4294969195""/>
+                  <nd ref=""4294969575""/>
+                  <tag k=""highway"" v=""residential""/>
+                  <tag k=""maxspeed:practical"" v=""12.910093541777924""/>
+                 </way>
+                </osm>
+                ";
+
+            Func<string, DateTime> parseToUniversalTime =
+                t => DateTime.Parse(t, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+            var serializer = new XmlSerializer(typeof(Osm));
+            var osm = serializer.Deserialize(new StringReader(xml)) as Osm;
+            Assert.IsNotNull(osm);
+            Assert.AreEqual(.6, osm.Version);
+            Assert.AreEqual("CGImap 0.7.5 (5035 errol.openstreetmap.org)", osm.Generator);
+
+            Assert.IsNull(osm.Relations);
+            Assert.IsNull(osm.User);
+            Assert.IsNull(osm.GpxFiles);
+            Assert.IsNull(osm.Api);
+
+            Assert.IsNotNull(osm.Bounds);
+            Assert.AreEqual(float.Parse("38.9070200"), osm.Bounds.MinLatitude);
+            Assert.AreEqual(float.Parse("-77.0371900"), osm.Bounds.MinLongitude);
+            Assert.AreEqual(float.Parse("38.9077300"), osm.Bounds.MaxLatitude);
+            Assert.AreEqual(float.Parse("-77.0360000"), osm.Bounds.MaxLongitude);
+
+            Assert.IsNotNull(osm.Nodes);
+            Assert.AreEqual(2, osm.Nodes.Length);
+            var node = osm.Nodes[0];
+            Assert.AreEqual(8549479, node.Id);
+            Assert.AreEqual(true, node.Visible);
+            Assert.AreEqual(6, node.Version);
+            Assert.AreEqual(17339, node.ChangeSetId);
+            Assert.AreEqual(parseToUniversalTime("2013-01-20T06:31:24Z"), node.TimeStamp);
+            Assert.AreEqual("samanbb", node.UserName);
+            Assert.AreEqual(933, node.UserId);
+            Assert.AreEqual(38.8921989, node.Latitude);
+            Assert.AreEqual(-77.0503034, node.Longitude);
+            Assert.IsNull(node.Tags);
+            node = osm.Nodes[1];
+            Assert.AreEqual(8549530, node.Id);
+            Assert.AreEqual(false, node.Visible);
+            Assert.AreEqual(2, node.Version);
+            Assert.AreEqual(17248, node.ChangeSetId);
+            Assert.AreEqual(parseToUniversalTime("2013-01-17T15:24:35Z"), node.TimeStamp);
+            Assert.AreEqual("ideditor", node.UserName);
+            Assert.AreEqual(912, node.UserId);
+            Assert.AreEqual(38.9065506, node.Latitude);
+            Assert.AreEqual(-77.0345080, node.Longitude);
+            Assert.IsNull(node.Tags);
+
+            Assert.IsNotNull(osm.Ways);
+            Assert.AreEqual(1, osm.Ways.Length);
+            var way = osm.Ways[0];
+            Assert.AreEqual(538868, way.Id);
+            Assert.AreEqual(true, way.Visible);
+            Assert.AreEqual(5, way.Version);
+            Assert.AreEqual(23710, way.ChangeSetId);
+            Assert.AreEqual(parseToUniversalTime("2013-05-28T17:45:26Z"), way.TimeStamp);
+            Assert.AreEqual("Kate", way.UserName);
+            Assert.AreEqual(1163, way.UserId);
+            Assert.NotNull(way.Nodes);
+            Assert.AreEqual(2, way.Nodes.Length);
+            Assert.AreEqual(4294969195, way.Nodes[0]);
+            Assert.AreEqual(4294969575, way.Nodes[1]);
+            Assert.NotNull(way.Tags);
+            Assert.AreEqual(2, way.Tags.Count);
+            Assert.True(way.Tags.ContainsKey("highway"));
+            Assert.AreEqual("residential", way.Tags["highway"]);
+            Assert.True(way.Tags.ContainsKey("maxspeed:practical"));
+            Assert.AreEqual("12.910093541777924", way.Tags["maxspeed:practical"]);
         }
     }
 }


### PR DESCRIPTION
Re: https://github.com/OsmSharp/core/issues/80

Fixing an issue where Xml deserialization never completes when the stream contains a Bounds XmlElement.

Includes a unit test.