### PR TITLE
Skip invalid note in xml

### DIFF
--- a/src/OsmSharp/IO/Xml/API/Osm.Xml.cs
+++ b/src/OsmSharp/IO/Xml/API/Osm.Xml.cs
@@ -127,11 +127,14 @@ namespace OsmSharp.API
                     {
                         var note = new Note();
                         (note as IXmlSerializable).ReadXml(reader);
-                        if (notes == null)
+                        if (note.Id.HasValue) // Ignore Notes missing content.
                         {
-                            notes = new List<Note>();
+                            if (notes == null)
+                            {
+                                notes = new List<Note>();
+                            }
+                            notes.Add(note);
                         }
-                        notes.Add(note);
                     }),
                 new Tuple<string, Action>(
                     "policy", () =>

--- a/test/OsmSharp.Test/IO/Xml/API/OsmTests.cs
+++ b/test/OsmSharp.Test/IO/Xml/API/OsmTests.cs
@@ -146,6 +146,7 @@ namespace OsmSharp.Test.IO.Xml.API
             Assert.IsNull(osm.GpxFiles);
             Assert.IsNull(osm.Bounds);
             Assert.IsNull(osm.Api);
+            Assert.IsNull(osm.Notes);
 
             Assert.IsNotNull(osm.Nodes);
             Assert.AreEqual(1, osm.Nodes.Length);
@@ -412,6 +413,7 @@ namespace OsmSharp.Test.IO.Xml.API
             var xml =
                 @"<?xml version=""1.0"" encoding=""UTF-8""?>
                 <osm>
+                    <note>This note should be skipped because it has no ID</note>
                     <note lon=""0.1000000"" lat=""51.0000000"">
                         <id>16659</id>
                         <url>https://master.apis.dev.openstreetmap.org/api/0.6/notes/16659</url>


### PR DESCRIPTION
OverpassApi always returns a `<note>` tag with a basic message in it. This was fine until I implemented Notes in OsmSharp, which made that tag parse as an empty Osm Note, which it really isn't. I've added a check to see if the note has an ID (which all real notes will have) and skip it if it doesn't.
I added tests for this issue also.