### PR TITLE
Replaced FilterSpatial contains with covers

### DIFF
--- a/src/OsmSharp.Geo/Extensions.cs
+++ b/src/OsmSharp.Geo/Extensions.cs
@@ -118,7 +118,7 @@ namespace OsmSharp.Geo
                 {
                     return false;
                 }
-                return polygon.Contains(new Point(n.Longitude.Value, n.Latitude.Value));
+                return polygon.Covers(new Point(n.Longitude.Value, n.Latitude.Value));
             }, completeWays);
             nodeFilter.RegisterSource(source);
             return nodeFilter;


### PR DESCRIPTION
The extension method FilterSpatial uses the NetTopologySuite's Contains method to select all points inside the given polygon. It seems to be better to use NetTopologySuite's Polygon.Covers() method for 2 reasons:

1. In situations where the polygon is created from a OSM boundary relation, by using "Contains", the relation is included in the result too. Furthermore, inner regions at the edges of the polygon will be included. This isn't the case right now. 
2. It is faster (according to the NetTopologySuite documentation):  "Covers should be used in preference to Contains. As an added benefit, Covers is more amenable to optimization, and hence should be more performant."  (http://nettopologysuite.github.io/NetTopologySuite/api/NetTopologySuite.Geometries.Geometry.html#NetTopologySuite_Geometries_Geometry_Covers_NetTopologySuite_Geometries_Geometry_)