### PR TITLE
Better handling of duplicate tag-keys in the PBF-Stream-Source

### DIFF
--- a/src/OsmSharp/Tags/TagsCollection.cs
+++ b/src/OsmSharp/Tags/TagsCollection.cs
@@ -112,6 +112,17 @@ namespace OsmSharp.Tags
         {
             _tags[tag.Key] = tag.Value;
         }
+        
+        public override bool TryAdd(string key, string value)
+        {
+            // TODO use _tags.TryAdd when OsmSharp ever uses netstandard 2.1
+            if (_tags.ContainsKey(key))
+            {
+                return false;
+            }
+            _tags.Add(key, value);
+            return true;
+        }
 
         /// <summary>
         /// Clears all tags.

--- a/src/OsmSharp/Tags/TagsCollectionBase.cs
+++ b/src/OsmSharp/Tags/TagsCollectionBase.cs
@@ -96,6 +96,26 @@ namespace OsmSharp.Tags
         }
 
         /// <summary>
+        /// Tries to add a key-value-pair to this collection.
+        /// If the value already exist, the addition fails and returns false
+        /// </summary>
+        /// <param name="key">The key of the tag</param>
+        /// <param name="value">The value of the tag</param>
+        /// <returns>true if the addition was successful</returns>
+        public abstract bool TryAdd(string key, string value);
+        
+        /// <summary>
+        /// Tries to add a key-value-pair to this collection.
+        /// If the value already exist, the addition fails and returns false
+        /// </summary>
+        /// <param name="tag">The tag to add</param>
+        /// <returns>true if the addition was successful</returns>
+        public bool TryAdd(Tag tag)
+        {
+            return TryAdd(tag.Key, tag.Value);
+        }
+
+        /// <summary>
         /// Returns true if the given tag exists.
         /// </summary>
         public bool ContainsKey(string key)


### PR DESCRIPTION
Hey,

Due to [this changeset](https://www.openstreetmap.org/changeset/90486873) (make sure to check the [osm source](https://www.openstreetmap.org/api/0.6/changeset/90486873/download) ), duplicate **keys** are introduced in the PBF-file. (Technically, there are control characters in the keys, making them non-identical to OSM but identical when converted to UTF8-strings)

In this PR, the following is added:

- A `TryAdd` method is introduced in `TagsCollectionBase` and `TagsCollection`. Right now, it still does a key lookup before an addition, but it can be converted to a native [`TryAdd`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.tryadd?view=netcore-3.1) once OsmSharp updates to netstandard2.1
- This `TryAdd` method is used instead of `Add` in the Encoder/Decoder. If a duplicate key is detected, an appropriate error message is written in the log (including the object-id in order to quickly find the offending tag)

No similar fix has been made in the XMLStreamSource, as it seems that these use a different decoder 