### PR TITLE
Do not ignore Relations with missing members in Complete

### DIFF
--- a/src/OsmSharp/Complete/Extensions.cs
+++ b/src/OsmSharp/Complete/Extensions.cs
@@ -120,7 +120,7 @@ namespace OsmSharp.Complete
                             var memberNode = osmGeoSource.GetNode(memberId);
                             if (memberNode == null)
                             {
-                                return null;
+                                continue;
                             }
                             var completeMemberNode = memberNode;
                             if (completeMemberNode != null)
@@ -129,14 +129,14 @@ namespace OsmSharp.Complete
                             }
                             else
                             {
-                                return null;
+                                continue;
                             }
                             break;
                         case OsmGeoType.Way:
                             var memberWay = osmGeoSource.GetWay(memberId);
                             if (memberWay == null)
                             {
-                                return null;
+                                continue;
                             }
                             var completeMemberWay = memberWay.CreateComplete(osmGeoSource);
                             if (completeMemberWay != null)
@@ -145,7 +145,7 @@ namespace OsmSharp.Complete
                             }
                             else
                             {
-                                return null;
+                                continue;
                             }
                             break;
                         case OsmGeoType.Relation:
@@ -154,7 +154,7 @@ namespace OsmSharp.Complete
                             var relationMember = osmGeoSource.GetRelation(memberId);
                             if (relationMember == null)
                             {
-                                return null;
+                                continue;
                             }
                             var completeMemberRelation = relationMember.CreateComplete(osmGeoSource);
                             if (completeMemberRelation != null)
@@ -163,7 +163,7 @@ namespace OsmSharp.Complete
                             }
                             else
                             {
-                                return null;
+                                continue;
                             }
                             break;
                     }


### PR DESCRIPTION
**Problem**: `IEnumerable<OsmGeo>.ToComplete()` filters (removes) Relations with any missing member.
Related https://github.com/OsmSharp/core/issues/63

**Fix / Workaround**: Instead of filtering those Relations, they are returned with the existing members.

This naive implementation does not check if there is at least one existing member, so Relations with no members could be returned. I think this is better than filtering with no warning because it should be easier to find the problem.

All tests that passed on the unmodified version (`TestDeserializeWithBoundsElement` failed) still pass.

