### PR TITLE
Fixes #132 block raw size expected

### DIFF
--- a/src/OsmSharp/IO/PBF/Encoder.cs
+++ b/src/OsmSharp/IO/PBF/Encoder.cs
@@ -311,13 +311,13 @@ namespace OsmSharp.IO.PBF
 
             if (groupDense.denseinfo != null)
             {
-                groupDense.denseinfo.changeset.Add(current.ChangeSetId.Value - previous.ChangeSetId.Value);
+                groupDense.denseinfo.changeset.Add((current.ChangeSetId ?? 0) - previous.ChangeSetId.Value);
                 var currentTimeStamp = Encoder.EncodeTimestamp(current.TimeStamp.Value, block.date_granularity);
                 var previousTimeStamp = previous.TimeStamp == null
                     ? 0
                     : Encoder.EncodeTimestamp(previous.TimeStamp.Value, block.date_granularity);
                 groupDense.denseinfo.timestamp.Add(currentTimeStamp - previousTimeStamp);
-                groupDense.denseinfo.uid.Add((int)(current.UserId.Value - previous.UserId.Value));
+                groupDense.denseinfo.uid.Add((int)((current.UserId ?? 0) - previous.UserId.Value));
                 groupDense.denseinfo.version.Add((int)(current.Version.Value - previous.Version.Value));
                 var previousUserNameId = previous.UserName == null
                     ? 0

--- a/src/OsmSharp/IO/PBF/PBFReader.cs
+++ b/src/OsmSharp/IO/PBF/PBFReader.cs
@@ -60,7 +60,7 @@ namespace OsmSharp.IO.PBF
 
         private readonly PrimitiveBlock _block = new PrimitiveBlock();
         private readonly BlobHeader _header = new BlobHeader();
-        
+
         /// <summary>
         /// Moves to the next primitive block, returns null at the end.
         /// </summary>
@@ -78,7 +78,7 @@ namespace OsmSharp.IO.PBF
             { // continue if there is still data but not a primitiveblock.
                 notFoundBut = false; // not found.
                 if (!Serializer.TryReadLengthPrefix(_stream, PrefixStyle.Fixed32BigEndian, out var length)) continue;
-                
+
                 // TODO: remove some of the v1 specific code.
                 // TODO: this means also to use the built-in capped streams.
 
@@ -89,13 +89,13 @@ namespace OsmSharp.IO.PBF
                 // actually need the other way around (network byte order):
                 // length = IntLittleEndianToBigEndian((uint)length);
 
-                
+
                 // again, v2 has capped-streams built in, but I'm deliberately
                 // limiting myself to v1 features
                 BlobHeader header;
                 using (var tmp = new LimitedStream(_stream, length))
                 {
-                    header = _runtimeTypeModel.Deserialize(tmp, _header, _blockHeaderType) as BlobHeader;
+                    header = _runtimeTypeModel.Deserialize<BlobHeader>(tmp, _header, _blockHeaderType);
                 }
                 Blob blob;
                 using (var tmp = new LimitedStream(_stream, header.datasize))
@@ -126,7 +126,7 @@ namespace OsmSharp.IO.PBF
 
                     if (header.type == Encoder.OSMData)
                     {
-                        block = _runtimeTypeModel.Deserialize(sourceStream, _block, _primitiveBlockType) as PrimitiveBlock;
+                        block = _runtimeTypeModel.Deserialize<PrimitiveBlock>(sourceStream, _block, _primitiveBlockType);
                     }
                 }
             }
@@ -196,7 +196,7 @@ namespace OsmSharp.IO.PBF
     }
     class ZLibStreamWrapper : InputStream
     {
-        private InflaterInputStream reader; 
+        private InflaterInputStream reader;
         public ZLibStreamWrapper(Stream stream)
         {
             reader = new InflaterInputStream(stream);

--- a/src/OsmSharp/IO/Zip/Streams/DeflaterOutputStream.cs
+++ b/src/OsmSharp/IO/Zip/Streams/DeflaterOutputStream.cs
@@ -30,6 +30,11 @@ namespace OsmSharp.IO.Zip.Streams
     /// </summary>
     public class DeflaterOutputStream : Stream
     {
+        /// <summary>
+        /// The default buffer size value in bytes.
+        /// </summary>
+        public const int DefaultBufferSize = 512;
+
         #region Constructors
         /// <summary>
         /// Creates a new DeflaterOutputStream with a default Deflater and default buffer size.
@@ -38,7 +43,7 @@ namespace OsmSharp.IO.Zip.Streams
         /// the output stream where deflated output should be written.
         /// </param>
         public DeflaterOutputStream(Stream baseOutputStream)
-            : this(baseOutputStream, new Deflater(), 512)
+            : this(baseOutputStream, new Deflater(), DefaultBufferSize)
         {
         }
 
@@ -53,7 +58,7 @@ namespace OsmSharp.IO.Zip.Streams
         /// the underlying deflater.
         /// </param>
         public DeflaterOutputStream(Stream baseOutputStream, Deflater deflater)
-            : this(baseOutputStream, deflater, 512)
+            : this(baseOutputStream, deflater, DefaultBufferSize)
         {
         }
 
@@ -96,7 +101,7 @@ namespace OsmSharp.IO.Zip.Streams
                 throw new ArgumentNullException(nameof(deflater));
             }
 
-            if (bufferSize < 512)
+            if (bufferSize < DefaultBufferSize)
             {
                 throw new ArgumentOutOfRangeException(nameof(bufferSize));
             }

--- a/src/OsmSharp/OsmSharp.csproj
+++ b/src/OsmSharp/OsmSharp.csproj
@@ -10,7 +10,7 @@
     <PackageTags>openstreetmap, osm</PackageTags>
   </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="protobuf-net" Version="2.4.6" />
+      <PackageReference Include="protobuf-net" Version="3.0.101" />
       <PackageReference Include="System.Text.Json" Version="5.0.2" />
     </ItemGroup>
 </Project>

--- a/src/OsmSharp/Streams/PBFOsmStreamTarget.cs
+++ b/src/OsmSharp/Streams/PBFOsmStreamTarget.cs
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 using OsmSharp.IO.PBF;
+using OsmSharp.IO.Zip;
 using OsmSharp.IO.Zip.Streams;
 using ProtoBuf.Meta;
 using System;
@@ -41,11 +42,22 @@ namespace OsmSharp.Streams
         private readonly Type _primitiveBlockType = typeof(PrimitiveBlock);
         private readonly Type _headerBlockType = typeof(HeaderBlock);
         private readonly bool _compress;
+        private readonly int _level;
+        private readonly int _bufferSize;
 
         /// <summary>
         /// Creates a new PBF stream target.
         /// </summary>
-        public PBFOsmStreamTarget(Stream stream, bool compress = true)
+        /// <param name="stream">The output stream.</param>
+        /// <param name="compress">if set to <c>true</c> use compression.</param>
+        /// <param name="compressionLevel">The compression level, a value between <see cref="Deflater.NO_COMPRESSION" />
+        /// and <see cref="Deflater.BEST_COMPRESSION" />, or <see cref="Deflater.DEFAULT_COMPRESSION" />.</param>
+        /// <param name="bufferSize">The buffer size in bytes to use when deflating (minimum value <see cref="DeflaterOutputStream.DefaultBufferSize"/>).</param>
+        public PBFOsmStreamTarget(
+            Stream stream, 
+            bool compress = true, 
+            int? compressionLevel = Deflater.DEFAULT_COMPRESSION, 
+            int? bufferSize = DeflaterOutputStream.DefaultBufferSize)
         {
             _stream = stream;
 
@@ -58,7 +70,10 @@ namespace OsmSharp.Streams
             _runtimeTypeModel.Add(_blobType, true);
             _runtimeTypeModel.Add(_primitiveBlockType, true);
             _runtimeTypeModel.Add(_headerBlockType, true);
+
             _compress = compress;
+            _level = compressionLevel ?? Deflater.DEFAULT_COMPRESSION;
+            _bufferSize = bufferSize ?? DeflaterOutputStream.DefaultBufferSize;
         }
 
         private List<OsmGeo> _currentEntities;
@@ -144,7 +159,7 @@ namespace OsmSharp.Streams
                 using (var target = new MemoryStream())
                 {
                     using (var source = new MemoryStream(blockBytes))
-                    using (var deflate = new DeflaterOutputStream(target))
+                    using (var deflate = new DeflaterOutputStream(target, new Deflater(_level), _bufferSize))
                     {
                         source.CopyTo(deflate);
                     }

--- a/src/OsmSharp/Streams/PBFOsmStreamTarget.cs
+++ b/src/OsmSharp/Streams/PBFOsmStreamTarget.cs
@@ -85,6 +85,7 @@ namespace OsmSharp.Streams
 
             // create blob.
             var blob = new Blob();
+            blob.raw_size = blockHeaderData.Length;
             if (_compress)
             {
                 using (var target = new MemoryStream())

--- a/test/OsmSharp.Test/IO/Xml/API/OsmTests.cs
+++ b/test/OsmSharp.Test/IO/Xml/API/OsmTests.cs
@@ -36,6 +36,8 @@ namespace OsmSharp.Test.IO.Xml.API
     [TestFixture]
     public class OsmTests
     {
+        private static readonly CultureInfo DefaultCultureInfo = new CultureInfo("en-US");
+
         /// <summary>
         /// Tests serialization.
         /// </summary>
@@ -197,10 +199,10 @@ namespace OsmSharp.Test.IO.Xml.API
             Assert.IsNull(osm.Api);
 
             Assert.IsNotNull(osm.Bounds);
-            Assert.AreEqual(float.Parse("38.9070200"), osm.Bounds.MinLatitude);
-            Assert.AreEqual(float.Parse("-77.0371900"), osm.Bounds.MinLongitude);
-            Assert.AreEqual(float.Parse("38.9077300"), osm.Bounds.MaxLatitude);
-            Assert.AreEqual(float.Parse("-77.0360000"), osm.Bounds.MaxLongitude);
+            Assert.AreEqual(float.Parse("38.9070200", DefaultCultureInfo), osm.Bounds.MinLatitude);
+            Assert.AreEqual(float.Parse("-77.0371900", DefaultCultureInfo), osm.Bounds.MinLongitude);
+            Assert.AreEqual(float.Parse("38.9077300", DefaultCultureInfo), osm.Bounds.MaxLatitude);
+            Assert.AreEqual(float.Parse("-77.0360000", DefaultCultureInfo), osm.Bounds.MaxLongitude);
 
             Assert.IsNotNull(osm.Nodes);
             Assert.AreEqual(2, osm.Nodes.Length);


### PR DESCRIPTION
* #132 fixes, output file in attachment ([fixed - resaved_api.osm.zip](https://github.com/OsmSharp/core/files/6947224/fixed.-.resaved_api.osm.zip)), no error occurs.
* Updated protobuf to v3.0 - looks promising: https://github.com/protobuf-net/protobuf-net/blob/main/docs/3_0.md

All tests are passed.