### PR TITLE
Fix writing dense nodes version

### DIFF
--- a/src/OsmSharp/IO/PBF/Encoder.cs
+++ b/src/OsmSharp/IO/PBF/Encoder.cs
@@ -318,7 +318,7 @@ namespace OsmSharp.IO.PBF
                     : Encoder.EncodeTimestamp(previous.TimeStamp.Value, block.date_granularity);
                 groupDense.denseinfo.timestamp.Add(currentTimeStamp - previousTimeStamp);
                 groupDense.denseinfo.uid.Add((int)((current.UserId ?? 0) - previous.UserId.Value));
-                groupDense.denseinfo.version.Add((int)(current.Version.Value - previous.Version.Value));
+                groupDense.denseinfo.version.Add((int)current.Version.Value);
                 var previousUserNameId = previous.UserName == null
                     ? 0
                     : Encoder.EncodeString(block, reverseStringTable, previous.UserName);


### PR DESCRIPTION
While looking around trying to see how hard it would be to support .Visible property I noticed that DenseNodes are delta encoding version, which they shouldn't...
Hence made fix and unit test...