### PR TITLE
Fix circular reference of relations which causes a stack overflow.

### DIFF
--- a/src/OsmSharp/Complete/Extensions.cs
+++ b/src/OsmSharp/Complete/Extensions.cs
@@ -93,18 +93,34 @@ namespace OsmSharp.Complete
         /// </summary>
         public static CompleteRelation CreateComplete(this Relation relation, IOsmGeoSource osmGeoSource)
         {
+            return relation.CreateComplete(osmGeoSource, new Dictionary<long, CompleteRelation>());
+        }
+        
+        private static CompleteRelation CreateComplete(this Relation relation, IOsmGeoSource osmGeoSource, Dictionary<long, CompleteRelation> createdRelations)
+        {
             if (relation == null) throw new ArgumentNullException("relation");
             if (relation.Id == null) throw new Exception("relation.Id is null");
             if (osmGeoSource == null) throw new ArgumentNullException("osmGeoSource");
 
-            var completeRelation = new CompleteRelation();
-            completeRelation.Id = relation.Id.Value;
+            var relationId = relation.Id.Value;
+            
+            // If we've already created this relation, return it (handles circular references)
+            if (createdRelations.TryGetValue(relationId, out var existingRelation))
+            {
+                return existingRelation;
+            }
 
+            // Create the complete relation and add it to the cache immediately
+            var completeRelation = new CompleteRelation();
+            completeRelation.Id = relationId;
             completeRelation.ChangeSetId = relation.ChangeSetId;
             if (relation.Tags != null)
             {
                 completeRelation.Tags = new TagsCollection(relation.Tags);
             }
+            // Add to cache before processing members to handle circular references
+            createdRelations[relationId] = completeRelation;
+
             if (relation.Members != null)
             {
                 var relationMembers = new List<CompleteRelationMember>();
@@ -156,7 +172,7 @@ namespace OsmSharp.Complete
                             {
                                 continue;
                             }
-                            var completeMemberRelation = relationMember.CreateComplete(osmGeoSource);
+                            var completeMemberRelation = relationMember.CreateComplete(osmGeoSource, createdRelations);
                             if (completeMemberRelation != null)
                             {
                                 member.Member = completeMemberRelation;

--- a/test/OsmSharp.Test/Stream/OsmSimpleCompleteStreamSourceTests.cs
+++ b/test/OsmSharp.Test/Stream/OsmSimpleCompleteStreamSourceTests.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using OsmSharp.Complete;
+using OsmSharp.Streams;
+using OsmSharp.Streams.Complete;
+
+namespace OsmSharp.Test.Stream;
+
+[TestFixture]
+public class OsmSimpleCompleteStreamSourceTests
+{
+    [Test]
+    public void SimpleComplete()
+    {
+        var streamSource = new XmlOsmStreamSource(Assembly.GetExecutingAssembly().GetManifestResourceStream(
+            "OsmSharp.Test.data.xml.circular-relation.osm"));
+        var completeSource = new OsmSimpleCompleteStreamSource(streamSource);
+        var element = completeSource.OfType<CompleteRelation>().ToList();
+        Assert.That(element.Count, Is.EqualTo(2));
+    }
+}

--- a/test/OsmSharp.Test/data/xml/circular-relation.osm
+++ b/test/OsmSharp.Test/data/xml/circular-relation.osm
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="openstreetmap-cgimap 2.1.0 (4146617 spike-07.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+    <relation id="3875817" visible="true" version="21" changeset="169825447" timestamp="2025-08-01T15:51:58Z" user="Dren ar Frankig" uid="11707888">
+        <member type="relation" ref="19253398" role="inner"/>
+        <tag k="access" v="yes"/>
+    </relation>
+    <relation id="19253398" visible="true" version="14" changeset="169825447" timestamp="2025-08-01T15:51:58Z" user="Dren ar Frankig" uid="11707888">
+        <member type="relation" ref="3875817" role="wall"/>
+        <tag k="name" v="Islamic Park of Israel"/>
+    </relation>
+</osm>


### PR DESCRIPTION
- Fixes #122

This adds a dictionary of relations in order to pass it down the recursion to use a reference of a relation when trying to create a complete one from it.

I've added a very simple test that throws stack overflow exception before this code change.
