### PR TITLE
Handle OSM JSON version as string

### DIFF
--- a/src/OsmSharp/IO/Json/Converters/OsmJsonConverter.cs
+++ b/src/OsmSharp/IO/Json/Converters/OsmJsonConverter.cs
@@ -41,7 +41,12 @@ namespace OsmSharp.IO.Json.Converters
                     switch (propertyName)
                     {
                         case "version":
-                            osm.Version = reader.GetDouble();
+                            osm.Version = reader.TokenType switch
+                            {
+                                JsonTokenType.Number => reader.GetDouble(),
+                                JsonTokenType.String => double.Parse(reader.GetString()),
+                                _ => throw new JsonException()
+                            };
                             break;
                         case "generator":
                             osm.Generator = reader.GetString();

--- a/test/OsmSharp.Test/IO/Json/API/OsmTests.cs
+++ b/test/OsmSharp.Test/IO/Json/API/OsmTests.cs
@@ -81,5 +81,17 @@ namespace OsmSharp.Test.IO.Json.API
             Assert.AreEqual(1, osm.Ways.Length);   
             Assert.AreEqual(1, osm.Relations.Length);   
         }
+
+       [Test]
+        public void Osm_FromJson_VersionAsString_ShouldReadVersion()
+        {
+            var osm = JsonSerializer.Deserialize<Osm>(
+                "{\"version\":\"0.6\",\"generator\":\"OsmSharp\",\"elements\":[]}"
+            );
+
+            Assert.NotNull(osm);
+            Assert.AreEqual(0.6, osm.Version);
+            Assert.AreEqual("OsmSharp", osm.Generator);
+        }
     }
 }


### PR DESCRIPTION
Fixes deserialization of OSM JSON when the `version` field is provided as a string instead of a numeric value.

Example:

```json
{
  "version": "0.6"
}
```

Changes Made:
* Updated `OsmJsonConverter` to support both numeric and string values for `version`
* Added regression test for string-based version parsing

Fixes #158
